### PR TITLE
Display adapter name when multiple choices

### DIFF
--- a/main.go
+++ b/main.go
@@ -112,7 +112,11 @@ func selectTarget(reports []kaginawa.Report) kaginawa.Report {
 	}
 	fmt.Printf("Multiple choices:\n")
 	for i, r := range reports {
-		fmt.Printf("%d: %s %s %s\n", i+1, r.ID, r.LocalIPv4, r.Hostname)
+		if len(r.LocalIPv4) == 0 && len(r.LocalIPv6) > 0 {
+			fmt.Printf("%d: %s %s@%s %s\n", i+1, r.ID, r.LocalIPv6, r.Adapter, r.Hostname)
+		} else {
+			fmt.Printf("%d: %s %s@%s %s\n", i+1, r.ID, r.LocalIPv4, r.Adapter, r.Hostname)
+		}
 	}
 	var n int
 	for {


### PR DESCRIPTION
issue #15 

sample prompt:
```
Multiple choices:
1: 18:93:7f:7b:19:c4 192.168.1.6@wlan0 ykm9-npinp2
2: 02:01:bd:79:ad:5e 192.168.1.6@eth0 ykm9-npinp2
```